### PR TITLE
add: getImpactSubScore, getExploitabilitySubScore functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ const vector = CVSS(
 console.log(vector.getScore()); // 3.6
 console.log(vector.getTemporalScore()); // 3.3
 console.log(vector.getEnvironmentalScore()); // 5.1
+console.log(vector.getImpactSubScore()) // 2.5
+console.log(vector.getExploitabilitySubScore()) // 1
 ```
 
 Sometimes it is useful to get a qualitative rating of a score

--- a/dist/cvss.d.ts
+++ b/dist/cvss.d.ts
@@ -18,4 +18,6 @@ declare function CVSS(vector: string): {
     getCleanVectorString: () => string;
     updateVectorValue: (metric: string, value: string) => string;
     isValid: true;
+    getImpactSubScore: () => number;
+    getExploitabilitySubScore: () => number;
 };

--- a/dist/score.d.ts
+++ b/dist/score.d.ts
@@ -16,3 +16,24 @@ export function getTemporalScore(vector: any): number;
  * @returns {Number} Environmental  Score
  */
 export function getEnvironmentalScore(vector: any): number;
+/**
+ * Returns an Exploitability sub score
+ *
+ * 8.22 x AttackVector x AttackComplexity x PrivilegeRequired x UserInteraction
+ *
+ * @param {String} vector
+ * @returns {Number} Exploitability sub score
+ */
+export function getExploitabilitySubScore(vector: any): number;
+/**
+ * Returns an Impact sub score
+ *
+ * ISCBase = 1 − [(1 − ImpactConf) × (1 − ImpactInteg) × (1 − ImpactAvail)]
+ *
+ * Scope Unchanged 6.42 × ISCBase
+ * Scope Changed 7.52 × [ISCBase − 0.029] − 3.25 × [ISCBase - 0.02]15
+ *
+ * @param {String} vector
+ * @returns {Number} Impact sub score
+ */
+export function getImpactSubScore(vector: any): number;

--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -150,6 +150,69 @@ function CVSS(vector) {
     throw new Error("The vector format is not valid!");
   }
 
+  /**
+   * Returns a Impact sub score
+   *
+   * 𝐼𝑆𝐶𝐵𝑎𝑠𝑒 = 1 − [(1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐶𝑜𝑛𝑓) × (1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐼𝑛𝑡𝑒𝑔) × (1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐴𝑣𝑎𝑖𝑙)]
+   *
+   * Scope Unchanged 6.42 × 𝐼𝑆𝐶Base
+   * Scope Changed 7.52 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.029] − 3.25 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.02]15
+   *
+   * @param {String} vector
+   * @returns {Number} Impact sub score
+   */
+  function getImpactSubScore() {
+    const vectorObject = util.getVectorObject(vector);
+    const C = util.findMetricValue("C", vectorObject).numerical;
+    const I = util.findMetricValue("I", vectorObject).numerical;
+    const A = util.findMetricValue("A", vectorObject).numerical;
+    const {S} = vectorObject;
+
+    // Calculate the impact using the formula from the CVSS v3.0 Specification Document
+    const impact = 1 - (1 - C) * (1 - I) * (1 - A);
+
+    // Check if the impact equal 0
+    if (impact === 0) return impact;
+
+    // If unchanged scope, multiply the impact by 6.42
+    let result = (6.42 * impact).toFixed(1);
+
+
+    // Check if the scope is changed
+    if (S === "C") {
+      // Scope Changed 7.52 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.029] − 3.25 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.02] ** 15
+      result = (7.52 * (impact - 0.029) - 3.25 * (impact - 0.02) ** 15).toFixed(1);
+    }
+
+    return Number(result);
+  }
+
+  /**
+   * Returns a Exploitability sub score
+   *
+   * 8.22 × 𝐴𝑡𝑡𝑎𝑐𝑘𝑉𝑒𝑐𝑡𝑜𝑟 × 𝐴𝑡𝑡𝑎𝑐𝑘𝐶𝑜𝑚𝑝𝑙𝑒𝑥𝑖𝑡𝑦 × 𝑃𝑟𝑖𝑣𝑖𝑙𝑒𝑔𝑒𝑅𝑒𝑞𝑢𝑖𝑟𝑒𝑑 × 𝑈𝑠𝑒𝑟𝐼𝑛𝑡𝑒𝑟𝑎𝑐𝑡𝑖𝑜𝑛
+   *
+   * @param {String} vector
+   * @returns {Number} Impact sub score
+   */
+  function getExploitabilitySubScore() {
+    const vectorObject = util.getVectorObject(vector);
+    const AV = util.findMetricValue("AV", vectorObject).numerical;
+    const AC = util.findMetricValue("AC", vectorObject).numerical;
+    const UI = util.findMetricValue("UI", vectorObject).numerical;
+    const PRObj = util.findMetricValue("PR", vectorObject).numerical;
+    const { S } = vectorObject;
+
+    let PR = PRObj.changed;
+
+    // check if scope unchanged
+    if (S === "U") PR = PRObj.unchanged;
+
+    const result = (8.22 * AV * AC * PR * UI).toFixed(1);
+
+    return Number(result);
+  }
+
   return {
     vector,
     getScore,
@@ -164,6 +227,8 @@ function CVSS(vector) {
     getCleanVectorString,
     updateVectorValue,
     isValid,
+    getImpactSubScore,
+    getExploitabilitySubScore,
   };
 }
 

--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -151,66 +151,30 @@ function CVSS(vector) {
   }
 
   /**
-   * Returns a Impact sub score
+   * Returns an Impact sub score
    *
-   * 𝐼𝑆𝐶𝐵𝑎𝑠𝑒 = 1 − [(1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐶𝑜𝑛𝑓) × (1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐼𝑛𝑡𝑒𝑔) × (1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐴𝑣𝑎𝑖𝑙)]
+   * ISCBase = 1 − [(1 − ImpactConf) × (1 − ImpactInteg) × (1 − ImpactAvail)]
    *
-   * Scope Unchanged 6.42 × 𝐼𝑆𝐶Base
-   * Scope Changed 7.52 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.029] − 3.25 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.02]15
+   * Scope Unchanged 6.42 × ISCBase
+   * Scope Changed 7.52 × [ISCBase − 0.029] − 3.25 × [ISCBase - 0.02]15
    *
    * @param {String} vector
    * @returns {Number} Impact sub score
    */
   function getImpactSubScore() {
-    const vectorObject = util.getVectorObject(vector);
-    const C = util.findMetricValue("C", vectorObject).numerical;
-    const I = util.findMetricValue("I", vectorObject).numerical;
-    const A = util.findMetricValue("A", vectorObject).numerical;
-    const {S} = vectorObject;
-
-    // Calculate the impact using the formula from the CVSS v3.0 Specification Document
-    const impact = 1 - (1 - C) * (1 - I) * (1 - A);
-
-    // Check if the impact equal 0
-    if (impact === 0) return impact;
-
-    // If unchanged scope, multiply the impact by 6.42
-    let result = (6.42 * impact).toFixed(1);
-
-
-    // Check if the scope is changed
-    if (S === "C") {
-      // Scope Changed 7.52 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.029] − 3.25 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.02] ** 15
-      result = (7.52 * (impact - 0.029) - 3.25 * (impact - 0.02) ** 15).toFixed(1);
-    }
-
-    return Number(result);
+    return Number(score.getImpactSubScore(vector).toFixed(1));
   }
 
   /**
-   * Returns a Exploitability sub score
+   * Returns an Exploitability sub score
    *
-   * 8.22 × 𝐴𝑡𝑡𝑎𝑐𝑘𝑉𝑒𝑐𝑡𝑜𝑟 × 𝐴𝑡𝑡𝑎𝑐𝑘𝐶𝑜𝑚𝑝𝑙𝑒𝑥𝑖𝑡𝑦 × 𝑃𝑟𝑖𝑣𝑖𝑙𝑒𝑔𝑒𝑅𝑒𝑞𝑢𝑖𝑟𝑒𝑑 × 𝑈𝑠𝑒𝑟𝐼𝑛𝑡𝑒𝑟𝑎𝑐𝑡𝑖𝑜𝑛
+   * 8.22 x AttackVector x AttackComplexity x PrivilegeRequired x UserInteraction
    *
    * @param {String} vector
-   * @returns {Number} Impact sub score
+   * @returns {Number} Exploitability sub score
    */
   function getExploitabilitySubScore() {
-    const vectorObject = util.getVectorObject(vector);
-    const AV = util.findMetricValue("AV", vectorObject).numerical;
-    const AC = util.findMetricValue("AC", vectorObject).numerical;
-    const UI = util.findMetricValue("UI", vectorObject).numerical;
-    const PRObj = util.findMetricValue("PR", vectorObject).numerical;
-    const { S } = vectorObject;
-
-    let PR = PRObj.changed;
-
-    // check if scope unchanged
-    if (S === "U") PR = PRObj.unchanged;
-
-    const result = (8.22 * AV * AC * PR * UI).toFixed(1);
-
-    return Number(result);
+    return Number(score.getExploitabilitySubScore(vector).toFixed(1));
   }
 
   return {

--- a/lib/score.js
+++ b/lib/score.js
@@ -75,18 +75,18 @@ function getEnvironmentalScore(vector) {
   if (!scopeChanged) {
     return roundUp(
       roundUp(Math.min(modifiedISC + modifiedExploitability, 10), 1, vector) *
-        eValue *
-        rlValue *
-        rcValue,
+      eValue *
+      rlValue *
+      rcValue,
       1,
       vector
     );
   }
   return roundUp(
     roundUp(Math.min(1.08 * (modifiedISC + modifiedExploitability), 10), 1, vector) *
-      eValue *
-      rlValue *
-      rcValue,
+    eValue *
+    rlValue *
+    rcValue,
     1,
     vector
   );
@@ -135,9 +135,9 @@ function calculateISCModifiedBase(vectorObject) {
 
   return Math.min(
     1 -
-      (1 - mcValue.numerical * crValue) *
-        (1 - miValue.numerical * irValue) *
-        (1 - maValue.numerical * arValue),
+    (1 - mcValue.numerical * crValue) *
+    (1 - miValue.numerical * irValue) *
+    (1 - maValue.numerical * arValue),
     0.915
   );
 }
@@ -175,8 +175,58 @@ function roundUp(num, precision, vector) {
   }
 }
 
+/**
+ * Returns an Impact sub score
+ *
+ * ISCBase = 1 − [(1 − ImpactConf) × (1 − ImpactInteg) × (1 − ImpactAvail)]
+ *
+ * Scope Unchanged 6.42 × ISCBase
+ * Scope Changed 7.52 × [ISCBase − 0.029] − 3.25 × [ISCBase - 0.02]15
+ *
+ * @param {String} vector
+ * @returns {Number} Impact sub score
+ */
+function getImpactSubScore(vector) {
+  const vectorObject = util.getVectorObject(vector);
+  const C = util.findMetricValue("C", vectorObject).numerical;
+  const I = util.findMetricValue("I", vectorObject).numerical;
+  const A = util.findMetricValue("A", vectorObject).numerical;
+  const {S} = vectorObject;
+
+  // Calculate the ISCBase using the formula from the CVSS v3.0 Specification Document
+  const ISCBase = 1 - (1 - C) * (1 - I) * (1 - A);
+
+  // Check if the ISCBase equal 0
+  if (ISCBase === 0) return ISCBase;
+
+  // Check if the scope is changed
+  if (S === "C") return calculateISC(ISCBase, true, vector);
+
+  return calculateISC(ISCBase, false, vector);
+}
+
+/**
+ * Returns an Exploitability sub score
+ *
+ * 8.22 x AttackVector x AttackComplexity x PrivilegeRequired x UserInteraction
+ *
+ * @param {String} vector
+ * @returns {Number} Exploitability sub score
+ */
+function getExploitabilitySubScore(vector) {
+  const vectorObject = util.getVectorObject(vector);
+  const {S} = vectorObject;
+
+  // check if scope unchanged
+  if (S === "U") return calculateExploitability(vectorObject, false);
+
+  return calculateExploitability(vectorObject, true);
+}
+
 module.exports = {
   getScore,
   getTemporalScore,
-  getEnvironmentalScore
+  getEnvironmentalScore,
+  getImpactSubScore,
+  getExploitabilitySubScore
 };

--- a/test/cvss.spec.js
+++ b/test/cvss.spec.js
@@ -568,3 +568,43 @@ describe("Update Vector Value Test", () => {
     ).toBe("CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N");
   });
 });
+
+describe("Impact Sub Score Tests", () => {
+  it("Should return the impact sub score equal 6.0", () => {
+    const vector = CVSS("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H");
+
+    expect(vector.getImpactSubScore()).toBe(6.0);
+  });
+
+  it("Should return the impact sub score equal 5.9", () => {
+    const vector = CVSS("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+
+    expect(vector.getImpactSubScore()).toBe(5.9);
+  });
+
+  it("Should return the impact sub score equal 0", () => {
+    const vector = CVSS("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N");
+
+    expect(vector.getImpactSubScore()).toBe(0);
+  });
+});
+
+describe("Exploitability sub score Tests", () => {
+  it("Should return the Exploitability sub score equal 3.9", () => {
+    const vector = CVSS("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H");
+
+    expect(vector.getExploitabilitySubScore()).toBe(3.9);
+  });
+
+  it("Should return the Exploitability sub score equal 0.9", () => {
+    const vector = CVSS("CVSS:3.0/AV:A/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H");
+
+    expect(vector.getExploitabilitySubScore()).toBe(0.9);
+  });
+
+  it("Should return the Exploitability sub score equal 0.1", () => {
+    const vector = CVSS("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N");
+
+    expect(vector.getExploitabilitySubScore()).toBe(0.1);
+  });
+});


### PR DESCRIPTION
# Description

Added new functions to calculate `Impact sub score` and ` Exploitability sub score` 
the Impact sub score (ISC) is defined as,

    Scope Unchanged 6.42 × 𝐼𝑆𝐶Base
    Scope Changed 7.52 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.029] − 3.25 × [𝐼𝑆𝐶𝐵𝑎𝑠𝑒 − 0.02]15

Where,

    𝐼𝑆𝐶𝐵𝑎𝑠𝑒 = 1 − [(1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐶𝑜𝑛𝑓) × (1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐼𝑛𝑡𝑒𝑔) × (1 − 𝐼𝑚𝑝𝑎𝑐𝑡𝐴𝑣𝑎𝑖𝑙)]

 And the Exploitability sub score is,

    8.22 × 𝐴𝑡𝑡𝑎𝑐𝑘𝑉𝑒𝑐𝑡𝑜𝑟 × 𝐴𝑡𝑡𝑎𝑐𝑘𝐶𝑜𝑚𝑝𝑙𝑒𝑥𝑖𝑡𝑦 × 𝑃𝑟𝑖𝑣𝑖𝑙𝑒𝑔𝑒𝑅𝑒𝑞𝑢𝑖𝑟𝑒𝑑 × 𝑈𝑠𝑒𝑟𝐼𝑛𝑡𝑒𝑟𝑎𝑐𝑡𝑖𝑜𝑛

Fixes #94

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
