### PR TITLE
Bugfix: Issue with score when CIA triad is None

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1267,6 +1267,12 @@ function eq3eq6CalculateLowerMacroVector(eqLevels) {
 }
 function getScore2(vector) {
   const vectorObj = util.getVectorObject(vector);
+  const allMetrics = ["VC", "VI", "VA", "SC", "SI", "SA"];
+  const allMetricsAreN = allMetrics.every((metric) => vectorObj[metric] === "N");
+  if (allMetricsAreN) {
+    const score2 = 0;
+    return parseFloat(score2.toFixed(1));
+  }
   const metrics = {
     AV: {},
     PR: {},

--- a/dist_node/index.js
+++ b/dist_node/index.js
@@ -1267,6 +1267,12 @@ function eq3eq6CalculateLowerMacroVector(eqLevels) {
 }
 function getScore2(vector) {
   const vectorObj = util.getVectorObject(vector);
+  const allMetrics = ["VC", "VI", "VA", "SC", "SI", "SA"];
+  const allMetricsAreN = allMetrics.every((metric) => vectorObj[metric] === "N");
+  if (allMetricsAreN) {
+    const score2 = 0;
+    return parseFloat(score2.toFixed(1));
+  }
   const metrics = {
     AV: {},
     PR: {},

--- a/lib/score_4_0.ts
+++ b/lib/score_4_0.ts
@@ -100,6 +100,14 @@ function eq3eq6CalculateLowerMacroVector(eqLevels: any) {
 function getScore(vector: string) {
   const vectorObj = util.getVectorObject(vector);
 
+  // Special case: if all metrics are N, return 0.0
+  const allMetrics = ['VC', 'VI', 'VA', 'SC', 'SI', 'SA'] as const;
+  const allMetricsAreN = allMetrics.every(metric => vectorObj[metric as keyof CvssVectorObject] === 'N');
+  if (allMetricsAreN) {
+    const score = 0.0;
+    return parseFloat(score.toFixed(1));
+  }
+
   const metrics = {
     AV: {} as Metric, // EQ1
     PR: {} as Metric, // EQ1

--- a/test/cvss_4_0.spec.ts
+++ b/test/cvss_4_0.spec.ts
@@ -64,7 +64,8 @@ const examples = [
     score: 9.7,
     vector: "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N/MSI:S/S:P"
   },
-  { score: 8.7, vector: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/V:C" }
+  { score: 8.7, vector: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/V:C" },
+  { score: 0.0, vector: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N" },
 ];
 
 describe("Score Tests", () => {


### PR DESCRIPTION
# Description

There is an issue when CIA triad is None. A test was added which was initially failing and now it was fixed. Solution inspired based on https://github.com/RedHatProductSecurity/cvss-v4-calculator/blob/main/cvss40.js

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
